### PR TITLE
Automate publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   },
   "scripts": {
     "build": "node scripts/build.js",
-    "test": "node scripts/test.js"
+    "test": "node scripts/test.js",
+    "publish": "node scripts/publish.js --"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,0 +1,53 @@
+const execSync = require("child_process").execSync;
+const packageJSON = require("../package.json");
+
+process.on('unhandledRejection', err => {
+  throw err;
+});
+
+const exec = (command, extraEnv) =>
+  execSync(command, {
+    stdio: "inherit",
+    env: Object.assign({}, process.env, extraEnv)
+  });
+
+const execOut = (command, extraEnv) =>
+  execSync(command, {
+    stdio: "pipe",
+    env: Object.assign({}, process.env, extraEnv)
+  }).toString('utf8').trim();
+
+const branch = execOut('git rev-parse --symbolic-full-name --abbrev-ref HEAD');
+
+if (branch !== 'master') {
+  console.log('You must be on branch "master" to run: npm run publish');
+  process.exit(1);
+}
+
+const bump = process.argv[3];
+
+if (!bump || !['major', 'minor', 'patch'].includes(bump)) {
+  console.log(`Please pass (major|minor|patch) as an argument.`);
+  console.log(`example: npm run publish minor`);
+  process.exit(1);
+}
+
+console.log('Making sure we have the latest master changes.');
+exec('git pull');
+
+console.log(`Creating new ${bump} version of react-governor.`);
+exec('npm run build');
+
+// This will fail and exit if the git working directory is not clean
+// This updates and commits the package.json
+console.log('Updating package.json');
+exec(`npm version ${bump}`);
+
+console.log('Pushing to npm repository');
+exec('npm publish --access public');
+
+console.log('Tagging branch');
+exec(`git tag v${packageJSON.version}`);
+
+console.log('Pushing to master');
+exec('git push');

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,5 +1,4 @@
 const execSync = require("child_process").execSync;
-const packageJSON = require("../package.json");
 
 process.on('unhandledRejection', err => {
   throw err;
@@ -43,6 +42,7 @@ exec('npm run build');
 console.log('Updating package.json');
 exec(`npm version ${bump}`);
 
+const packageJSON = require("../package.json");
 console.log('Pushing to npm repository');
 exec('npm publish --access public');
 


### PR DESCRIPTION
This adds a `publish.js` script that automates the publishing process and makes it a little more fail safe.

Instead of building and doing the process yourself, now you can run:
`npm run publish (major|minor|patch)`

This will do the following:
 - Verifies you're on the master branch
 - Verifies you've selected major, minor, or patch
 - Ensures you have the latest master
 - Build the production bundle
 - Bumps and commits the `package.json` (will fail if the working directory is not clean +1)
 - Publishes publicly to npm
 - Tags the commit
 - Pushes the result

Useful here and in any upcoming npm libraries we may publish.. because everyone should have a custom hooks library! 👀 