### PR TITLE
Updated lint rules and fixed a warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-react": "7.11.1",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "gzip-size": "^5.0.0",
     "jest": "23.6.0",
     "jest-pnp-resolver": "1.0.1",
@@ -72,7 +73,14 @@
     "publish": "node scripts/publish.js --"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "plugins": [
+      "react-hooks"
+    ],
+    "rules": {
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn"
+    }
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,9 @@ export function useGovernor(initialState = {}, contract = {}) {
     initialState
   );
 
-  const hookActions = useMemo(() => new HookActions(contract, dispatch), []);
+  const hookActions = useMemo(() => new HookActions(contract, dispatch), [
+    contract
+  ]);
   hookActions.__state = state;
 
   return [state, hookActions];


### PR DESCRIPTION
Supports recomputing `HookActions` when the contract has changed. Mainly, this was just removing a warning from the linter, but it does support odd use-cases like:
```jsx
const contract = { 
  foo() { 
    console.log("foo"); 
  } 
};

function Test() {
  const [state, actions] = useGovernor({}, contract);

  useEffect(() => {
    contract.bar = function() {
      console.log("bar");
    };
  }, []);
}
```
Why on earth anyone would want to do this is beyond me, but it is now supported.