### PR TITLE
Allow class contract

### DIFF
--- a/src/examples/class-counter/Counter.js
+++ b/src/examples/class-counter/Counter.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { useGovernor } from "../..";
+import { initialState, contract } from "./CounterContract";
+
+export default function Counter() {
+  const [state, actions] = useGovernor(initialState, contract);
+
+  return (
+    <div>
+      <input className="val" value={state.count} readOnly />
+      <button className="inc" onClick={() => actions.increment()} />
+      <button className="dec" onClick={() => actions.decrement()} />
+      <button className="add5" onClick={() => actions.add(5)} />
+      <button className="set" onClick={() => actions.set(137)} />
+      <button className="addSum" onClick={() => actions.addSum(3, 4)} />
+
+      <input className="newState" value={state.newState} readOnly />
+      <button
+        className="addNewState"
+        onClick={() => actions.addNewState("Hello")}
+      />
+      <button className="removeState" onClick={() => actions.removeState()} />
+      <button className="asyncFunc" onClick={actions.asyncFunc} />
+      <input className="googleStatus" value={state.status} />
+      <button className="fetchGoogle" onClick={actions.fetchGoogle} />
+    </div>
+  );
+}

--- a/src/examples/class-counter/CounterContract.js
+++ b/src/examples/class-counter/CounterContract.js
@@ -1,0 +1,65 @@
+import fetch from "cross-fetch";
+
+export const initialState = {
+  count: 0
+};
+
+export class contract {
+  increment(state) {
+    return {
+      count: state.count + 1
+    };
+  }
+  decrement(state) {
+    return {
+      count: state.count - 1
+    };
+  }
+  add(val, state) {
+    return {
+      count: state.count + val
+    };
+  }
+  set(val) {
+    return {
+      count: val
+    };
+  }
+  addSum(val, val2, state) {
+    return {
+      count: state.count + val + val2
+    };
+  }
+  addNewState(val) {
+    return {
+      ...this.state,
+      newState: val
+    };
+  }
+  removeState() {
+    return {};
+  }
+  async asyncFunc() {
+    // Block with a promise that resolved a new count
+    const count = await new Promise(resolve =>
+      setTimeout(() => {
+        resolve(256);
+      }, 1000)
+    );
+    // set the state count to our promised count
+    return {
+      count: count
+    };
+  }
+  async fetchGoogle() {
+    let google = await fetch("https://www.google.com");
+    return {
+      status: google.status
+    };
+  }
+  statedInc() {
+    return {
+      count: this.state.count + 1
+    };
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,18 +4,17 @@ class HookActions {
   constructor(contract, dispatch) {
     this.__dispatch = dispatch;
 
-    let instance = contract;
-    let keys = contract;
     if (typeof contract === "function") {
-      instance = new contract();
-      Object.getOwnPropertyNames(instance.__proto__)
-        .splice(1)
-        .forEach(key => (keys[key] = key));
+      const _contract = new contract();
+      contract = {};
+      Object.getOwnPropertyNames(_contract.__proto__)
+        .splice(1) // remove the constructor
+        .forEach(key => (contract[key] = _contract[key]));
     }
 
-    for (let key in keys) {
+    for (let key in contract) {
       this[key] = async (...args) => {
-        const newState = await instance[key].apply({ state: this.__state }, [
+        const newState = await contract[key].apply({ state: this.__state }, [
           ...args,
           this.__state
         ]);
@@ -41,7 +40,7 @@ export function useGovernor(initialState = {}, contract = {}) {
     (typeof contract !== "object" && typeof contract !== "function")
   ) {
     throw new TypeError(
-      `contract is invalid: expected "object"; got "${typeof contract}"`,
+      `contract is invalid: expected "object" or "class"; got "${typeof contract}"`,
       contract
     );
   }

--- a/src/tests/class-counter/Counter.spec.js
+++ b/src/tests/class-counter/Counter.spec.js
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom";
 import { act } from "react-dom/test-utils";
 import TestRenderer from "react-test-renderer";
 
-import Counter from "../../examples/counter/Counter";
+import Counter from "../../examples/class-counter/Counter";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -3,8 +3,6 @@ import { useGovernor } from "..";
 it("throws errors on invalid contract", () => {
   expect(() => useGovernor({}, null)).toThrow("contract is invalid");
   expect(() => useGovernor({}, "break")).toThrow("contract is invalid");
-  expect(() => useGovernor({}, function() {})).toThrow("contract is invalid");
   expect(() => useGovernor({}, 1)).toThrow("contract is invalid");
-  expect(() => useGovernor({}, () => {})).toThrow("contract is invalid");
   expect(() => useGovernor({}, 1)).toThrow("contract is invalid");
 });

--- a/src/tests/simple-counter/SimpleCounter.spec.js
+++ b/src/tests/simple-counter/SimpleCounter.spec.js
@@ -22,7 +22,7 @@ it("can increment", async () => {
   const val = counter.root.findByProps({ className: "val" });
   const button = counter.root.findByProps({ className: "inc" });
 
-  await act(async() => {
+  await act(async () => {
     expect(val.props.value).toBe(0);
 
     await button.props.onClick();
@@ -40,7 +40,7 @@ it("can decrement", async () => {
   const val = counter.root.findByProps({ className: "val" });
   const button = counter.root.findByProps({ className: "dec" });
 
-  await act(async() => {
+  await act(async () => {
     expect(val.props.value).toBe(0);
 
     await button.props.onClick();
@@ -58,7 +58,7 @@ it("can add5", async () => {
   const val = counter.root.findByProps({ className: "val" });
   const button = counter.root.findByProps({ className: "add5" });
 
-  await act(async() => {
+  await act(async () => {
     expect(val.props.value).toBe(0);
 
     await button.props.onClick();
@@ -76,7 +76,7 @@ it("can sub2", async () => {
   const val = counter.root.findByProps({ className: "val" });
   const button = counter.root.findByProps({ className: "sub2" });
 
-  await act(async() => {
+  await act(async () => {
     expect(val.props.value).toBe(0);
 
     await button.props.onClick();


### PR DESCRIPTION
Provides support for declaring the contract as a class rather than an object.

For example:

```js
export class contract {
  increment() {
    return {
      ...this.state,
      count: this.state.count + 1
    };
  }
  decrement() {
    return {
      ...this.state,
      count: this.state.count - 1
    };
  }
}
```

Since the contracts are basically decorators, I thought this looked a little cleaner than an object - there are no commas between the functions, and it is more intuitive to think of the `actions` provided by `useGovernor` as a class with functions than an object with keyed functions.