### PR TITLE
More tests and fix throwing reducer errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  - "lts/*"
+  - "12"
 cache:
   directories:
     - node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techempower/react-governor",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The easiest way to govern over your application's state and actions.",
   "license": "BSD-3",
   "repository": {

--- a/src/examples/counter/Counter.js
+++ b/src/examples/counter/Counter.js
@@ -20,8 +20,14 @@ export default function Counter() {
         onClick={() => actions.addNewState("Hello")}
       />
       <button className="removeState" onClick={() => actions.removeState()} />
-      <button className="actionWithoutReducer" onClick={() => actions.actionWithoutReducer()} />
-      <button className="asyncActionWithoutReducer" onClick={() => actions.asyncActionWithoutReducer()} />
+      <button
+        className="actionWithoutReducer"
+        onClick={() => actions.actionWithoutReducer()}
+      />
+      <button
+        className="asyncActionWithoutReducer"
+        onClick={() => actions.asyncActionWithoutReducer()}
+      />
       <button className="asyncFunc" onClick={() => actions.asyncFunc()} />
       <button
         className="compoundAsyncFunc"

--- a/src/examples/counter/Counter.js
+++ b/src/examples/counter/Counter.js
@@ -20,6 +20,8 @@ export default function Counter() {
         onClick={() => actions.addNewState("Hello")}
       />
       <button className="removeState" onClick={() => actions.removeState()} />
+      <button className="actionWithoutReducer" onClick={() => actions.actionWithoutReducer()} />
+      <button className="asyncActionWithoutReducer" onClick={() => actions.asyncActionWithoutReducer()} />
       <button className="asyncFunc" onClick={() => actions.asyncFunc()} />
       <button
         className="compoundAsyncFunc"

--- a/src/examples/counter/CounterContract.js
+++ b/src/examples/counter/CounterContract.js
@@ -39,6 +39,12 @@ export const contract = {
   removeState() {
     return () => ({});
   },
+  actionWithoutReducer() {
+    return {};
+  },
+  async asyncActionWithoutReducer() {
+    return {};
+  },
   async asyncFunc() {
     // Block with a promise that resolved a new count
     const count = await new Promise(resolve =>

--- a/src/examples/render-counting/Counter.js
+++ b/src/examples/render-counting/Counter.js
@@ -3,11 +3,14 @@ import { useGovernor } from "../..";
 import { initialState, contract } from "./CounterContract";
 
 let numRenders = 0;
+let isCountEver14 = false;
 
 export default function Counter() {
   const [state, actions] = useGovernor(initialState, contract);
 
   useEffect(() => {
+    // this should all happen in the correct order, and in 1
+    // render, leaving us with a count of 8
     actions.set(0);
     actions.add(5);
     actions.multiply(0);
@@ -16,14 +19,28 @@ export default function Counter() {
   }, [actions]);
 
   useEffect(() => {
-    if (state.count === 2) {
-      actions.set(-1);
+    if (state.count === 14) {
+      isCountEver14 = true;
     }
-  }, [actions, state.count]);
+  }, [state.count]);
 
   useEffect(() => {
     if (state.count === 8) {
+      /**
+       * Even though this async action returns immediately,
+       * its reducer should only be applied once the rest of
+       * the sync actions have completed. If this happened in
+       * order, count would be 18. Instead, it should be 28.
+       *
+       * Because one of our actions is async, the component will
+       * finish rendering before the async action's reducer is
+       * applied. The component will render with the count of 14,
+       * (8 / 2 + 10), and then finish the side effect, rendering
+       * an additional time.
+       */
+      actions.asyncMultiply(2);
       actions.divide(2);
+      actions.add(10);
     }
   }, [actions, state.count]);
 
@@ -33,6 +50,7 @@ export default function Counter() {
     <>
       <div className="count">{state.count}</div>
       <div className="num-renders">{numRenders}</div>
+      <div className="count-14">{isCountEver14.toString()}</div>
     </>
   );
 }

--- a/src/examples/render-counting/CounterContract.js
+++ b/src/examples/render-counting/CounterContract.js
@@ -22,5 +22,10 @@ export const contract = {
     return () => ({
       count: this.state.count / val
     });
+  },
+  async asyncMultiply(val) {
+    return () => ({
+      count: this.state.count * val
+    });
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { useMemo, useReducer } from "react";
 
-class HookActions {
+class Governor {
   constructor(contract, dispatch) {
     this.dispatch = dispatch;
     this.actions = {};
@@ -133,12 +133,10 @@ function useGovernor(initialState, contract) {
 
   const [state, dispatch] = useReducer(reducer, initialState);
 
-  const hookActions = useMemo(() => new HookActions(contract, dispatch), [
-    contract
-  ]);
-  hookActions.__state = state;
+  const governor = useMemo(() => new Governor(contract, dispatch), [contract]);
+  governor.__state = state;
 
-  return [state, hookActions.actions];
+  return [state, governor.actions];
 }
 
 export { useGovernor };

--- a/src/index.js
+++ b/src/index.js
@@ -4,18 +4,17 @@ class Governor {
   constructor(contract, dispatch) {
     this.dispatch = dispatch;
     this.actions = {};
-    this.contract = contract;
 
     for (let actionKey in contract) {
-      if (typeof this.contract[actionKey] !== "function") {
+      if (typeof contract[actionKey] !== "function") {
         throw new TypeError(
-          `action is invalid: expected "function"; for "${typeof this.contract[
+          `action is invalid: expected "function"; for "${typeof contract[
             actionKey
           ]}"`
         );
       }
 
-      this.createAction(actionKey);
+      this.createAction(contract[actionKey], actionKey);
     }
   }
 
@@ -62,11 +61,12 @@ class Governor {
    *   }
    * }
    *
-   * @param {function} actionKey
+   * @param {function} action
+   * @param {string} actionKey
    */
-  createAction(actionKey) {
+  createAction(action, actionKey) {
     this.actions[actionKey] = (...args) => {
-      const reducerOrPromise = this.contract[actionKey].apply(this, [...args]);
+      const reducerOrPromise = action.apply(this, [...args]);
 
       // If we have a Promise we do not want to dispatch until it resolves.
       if (reducerOrPromise && reducerOrPromise.then) {

--- a/src/index.js
+++ b/src/index.js
@@ -61,12 +61,12 @@ class Governor {
    *   }
    * }
    *
-   * @param {function} action
+   * @param {function} createReducer
    * @param {string} actionKey
    */
-  createAction(action, actionKey) {
+  createAction(createReducer, actionKey) {
     this.actions[actionKey] = (...args) => {
-      const reducerOrPromise = action.apply(this, [...args]);
+      const reducerOrPromise = createReducer.apply(this, [...args]);
 
       // If we have a Promise we do not want to dispatch until it resolves.
       if (reducerOrPromise && reducerOrPromise.then) {

--- a/src/tests/counter/Counter.spec.js
+++ b/src/tests/counter/Counter.spec.js
@@ -144,6 +144,23 @@ it("can removeState", () => {
   });
 });
 
+it("properly reports action error", () => {
+  const counter = TestRenderer.create(<Counter />);
+  const button = counter.root.findByProps({
+    className: "actionWithoutReducer"
+  });
+
+  act(() => {
+    // ReactDOM will still output an error to the console; let's hide that for this test
+    const tmp = console.error;
+    console.error = function() {};
+    expect(() => button.props.onClick()).toThrow(
+      `action "actionWithoutReducer" must return a reducer function; instead got "object"`
+    );
+    console.error = tmp;
+  });
+});
+
 it("can asyncFunc", async () => {
   const counter = TestRenderer.create(<Counter />);
   const val = counter.root.findByProps({ className: "val" });

--- a/src/tests/index.spec.js
+++ b/src/tests/index.spec.js
@@ -1,6 +1,7 @@
 import { useGovernor } from "..";
 
 it("throws errors on invalid contract", () => {
+  expect(() => useGovernor({})).toThrow("contract is invalid");
   expect(() => useGovernor({}, null)).toThrow("contract is invalid");
   expect(() => useGovernor({}, "break")).toThrow("contract is invalid");
   expect(() => useGovernor({}, 1)).toThrow("contract is invalid");

--- a/src/tests/render-counting/RenderCounting.spec.js
+++ b/src/tests/render-counting/RenderCounting.spec.js
@@ -4,15 +4,18 @@ import { act } from "react-dom/test-utils";
 
 import Counter from "../../examples/render-counting/Counter";
 
-it("re-renders the correct number of times", () => {
+it("re-renders the correct number of times", async () => {
   const el = document.createElement("div");
 
-  act(() => {
+  await act(async () => {
     ReactDOM.render(<Counter />, el);
     // Initial render
-    expect(el.querySelector('.count').innerHTML).toBe("0");
+    expect(el.querySelector(".count").innerHTML).toBe("0");
+
+    await new Promise(resolve => setTimeout(resolve, 1000));
   });
 
-  expect(el.querySelector('.count').innerHTML).toBe("4");
-  expect(el.querySelector('.num-renders').innerHTML).toBe("3");
+  expect(el.querySelector(".count").innerHTML).toBe("28");
+  expect(el.querySelector(".num-renders").innerHTML).toBe("4");
+  expect(el.querySelector(".count-14").innerHTML).toBe("true");
 });


### PR DESCRIPTION
This PR does a few things:

 - Removes the `initialState = {}` default in `useGovernor`. A user may want `undefined` as initial state and this default would override that.
 - Removes the `contract = {}` default and instead throws an error if `contract` is `undefined`.
 - Adds a test for ^
 - Updates the render counting test to include an async action that returns immediately and added some comments about what the expected behavior is
 - Adds a test for properly throwing an error when a reducer isn't returned from an action
 - What the heck is `HookActions` anyway? I don't think that name makes sense anymore. I think it's the `Governor`
 - *reduced lines of code* in the governor by moving some duplicated code into `dispatchFromActionReducer` and simplifying `createAction`
 - Removes `this.contract` from Governor instances. No need to have this and just increases the memory footprint of each instance. 

One thing I can't quite figure out is testing the `asyncActionWithoutReducer` action I added. I've tried all combinations of catching it within an async `act()`, sleeping, wrapping all of `act()` in a `try/catch`. The error always breaks out of the `it()` block, but testing in a codesandbox confirms it works correctly.

