### PR TITLE
Fix initialState bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@techempower/react-governor",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "The easiest way to govern over your application's state and actions.",
   "license": "BSD-3",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { useMemo, useReducer } from "react";
+import { useReducer, useState } from "react";
 
 class Governor {
   constructor(contract, dispatch, initialState, middlewares = []) {
@@ -147,10 +147,8 @@ function useGovernor(initialState, contract, middlewares) {
   }
 
   const [state, dispatch] = useReducer(reducer, initialState);
-
-  const governor = useMemo(
-    () => new Governor(contract, dispatch, initialState, middlewares),
-    [contract, initialState, middlewares]
+  const [governor] = useState(
+    new Governor(contract, dispatch, initialState, middlewares)
   );
 
   governor.__state = state;


### PR DESCRIPTION
### The Problem

First, we were relying, incorrectly, on `useMemo` to make sure the instance of the `Governor` class inside the `useGovernor` hook wasn't re-instantiated on every render. The problem is that, depending on how big your app is and how much memory you're using, react can decide to rerun the `useMemo` hook whenever it wants, even if dependencies haven't changed. From the React docs:

> You may rely on useMemo as a performance optimization, not as a semantic guarantee. In the future, React may choose to “forget” some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. Write your code so that it still works without useMemo — and then add it to optimize performance.

Our tests do not pass if we remove the `useMemo` optimization because creating a new instance of the `Governor` class based on `initialState` on every render would cause us to lose state updates.

Similarly, we want `useGovernor(initialState)` to work the same way `useState(initialState)` would work. Consider the following component:

```
const DateWat = () => {
  const initialState = new Date().getTime();
  const [state, setState] = useState(initialState);

  return (
    <div onClick={() => setState("Clicked")}>
      {state}
    </div>
  );
};
```

Clicking on the time will cause this component to rerender. When it does, you might expect `initialState` to be recalculated (well, it is), but `useState` won't update the state value to that new time because `useState` only sets the initial state the first time it's mounted. Here's the example: https://codesandbox.io/s/react-governor-complex-embedded-czyd0

`useGovernor` was doing this wrong. When that `initialState` was recalculated, the `useMemo` hook in `useGovernor` was recalculated, giving us a new instance of the `Governor` class.

### The Solution

To get the same effect `useState` gives us we simply use... `useState`. By replacing `useMemo` with `useState` to create the `Governor` instance, we ensure we're using the same instance the entire time the component is mounted. If `initialState` happens to change because `intialState` was created inside the same component for whatever reason (maybe they needed to reference props to create that `initialState`), it won't disrupt the current state.